### PR TITLE
Enhance Whisper model audio processing and testing

### DIFF
--- a/jsgrad/models/whisper.ts
+++ b/jsgrad/models/whisper.ts
@@ -350,7 +350,7 @@ class TextDecoder {
   output_tok = async (x: Tensor) => await this.ln.call(x).matmul(this.token_embedding.weight.T).realize()
 }
 
-class Whisper {
+export class Whisper {
   encoder!: AudioEncoder
   decoder!: TextDecoder
   is_multilingual!: boolean
@@ -566,7 +566,7 @@ export const transcribe_file = async (model: any, enc: Tokenizer, filename: stri
  * Returns the transcribed text if a single waveform is provided, or an array of transcriptions if multiple are provided
  */
 const transcribe_waveform = async (model: Whisper, enc: Tokenizer, waveforms: Float32Array[], truncate = false, language?: string) => {
-  // maybe is better merge the channels
+  // maybe it's better merge the channels
   const mono_waveform = [waveforms[0]];
   const log_spec = await vars.withAsync({ DEVICE: env.CPU_DEVICE }, async () => await prep_audio(mono_waveform, model.batch_size, truncate));
 

--- a/jsgrad/models/whisper.ts
+++ b/jsgrad/models/whisper.ts
@@ -597,7 +597,7 @@ const transcribe_waveform = async (model: Whisper, enc: Tokenizer, waveforms: Fl
   const eot = enc.special_tokens['<|endoftext|>']
 
   let ctx = new Tensor(start_tokens).reshape([1, -1]).expand([model.batch_size, start_tokens.length])
-  let transcriptions: number[][] = waveforms.map(() => [])
+  let transcriptions: number[][] = mono_waveform.map(() => [])
 
   for (const curr_frame of range(0, log_spec.shape_num.at(-1), FRAMES_PER_SEGMENT)) {
     const encoded_audio = await model.encoder.encode.call(log_spec.get({}, {}, { start: curr_frame, stop: curr_frame + FRAMES_PER_SEGMENT }))
@@ -609,7 +609,7 @@ const transcribe_waveform = async (model: Whisper, enc: Tokenizer, waveforms: Fl
     }
 
     for (const [i, [res, arr]] of zip(transcriptions, await ctx.tolist<number[][]>()).entries()) {
-      if (curr_frame * HOP_LENGTH <= waveforms[i].length) {
+      if (curr_frame * HOP_LENGTH <= mono_waveform[i].length) {
         const start = arr.indexOf(start_tokens.at(-1)!) + 1
         res.push(...arr.slice(start, arr.indexOf(eot, start)))
       }

--- a/jsgrad/models/whisper.ts
+++ b/jsgrad/models/whisper.ts
@@ -155,7 +155,7 @@ const get_mel = async (sr: number, n_fft: number, n_mels = 128, fmin = 0.0, fmax
   const fdiff = mel_f.get({ start: 1 }).sub(mel_f.get({ stop: -1 }))
   const ramps = mel_f.reshape([-1, 1]).sub(fftfreqs.reshape([1, -1]))
 
-  const t = []
+  const t: Tensor[] = []
   for (const i of range(n_mels)) {
     const lower = ramps.get(i).neg().div(fdiff.get(i))
     const upper = ramps.get(i + 2).div(fdiff.get(i + 1))
@@ -481,7 +481,7 @@ const wav = (bytes: Uint8Array) => {
     throw new Error('Not a valid WAV file')
   }
 
-  let offset = 12, sampleRate = 0, numChannels = 0, bitsPerSample = 0, audioData = null
+  let offset = 12, sampleRate = 0, numChannels = 0, bitsPerSample = 0, audioData: null | Uint8Array = null
 
   while (offset < bytes.length) {
     const chunkId = String.fromCharCode(...bytes.slice(offset, offset + 4))
@@ -542,6 +542,7 @@ export const transcribe_file = async (model: any, enc: Tokenizer, filename: stri
  * Returns the transcribed text if a single waveform is provided, or an array of transcriptions if multiple are provided
  */
 const transcribe_waveform = async (model: Whisper, enc: Tokenizer, waveforms: Float32Array[], truncate = false, language?: string) => {
+  // maybe is better merge the channels
   const mono_waveform = [waveforms[0]];
   const log_spec = await vars.withAsync({ DEVICE: env.CPU_DEVICE }, async () => await prep_audio(mono_waveform, model.batch_size, truncate));
 

--- a/jsgrad/models/whisper.ts
+++ b/jsgrad/models/whisper.ts
@@ -542,8 +542,8 @@ export const transcribe_file = async (model: any, enc: Tokenizer, filename: stri
  * Returns the transcribed text if a single waveform is provided, or an array of transcriptions if multiple are provided
  */
 const transcribe_waveform = async (model: Whisper, enc: Tokenizer, waveforms: Float32Array[], truncate = false, language?: string) => {
-  let log_spec = await vars.withAsync({ DEVICE: env.CPU_DEVICE }, async () => await prep_audio(waveforms, model.batch_size, truncate))
-  log_spec = log_spec.to(Device.DEFAULT)
+  const mono_waveform = [waveforms[0]];
+  const log_spec = await vars.withAsync({ DEVICE: env.CPU_DEVICE }, async () => await prep_audio(mono_waveform, model.batch_size, truncate));
 
   const nsample = model.decoder.max_tokens_to_sample
 

--- a/test/models/whisper.test.ts
+++ b/test/models/whisper.test.ts
@@ -1,98 +1,84 @@
-import { describe, test, expect, beforeAll } from "vitest";
-import {
-  init_whisper,
-  transcribe_file,
-  MODELS,
-  type WhisperModel,
-  type Whisper as WhisperModelType,
-  type Tokenizer,
-  env,
-  id,
-} from "../../jsgrad/node.ts";
+import { beforeAll, describe, expect, test } from 'vitest'
+import { env, id, init_whisper, MODELS, type Tokenizer, transcribe_file, type Whisper as WhisperModelType, type WhisperModel } from '../../jsgrad/node.ts'
 
-describe("Whisper Model", () => {
-  let whisperInstance: { model: WhisperModelType; enc: Tokenizer } | undefined =
-    undefined;
-  const testModel: WhisperModel = "tiny.en";
-  const testAudioUrl =
-    "https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/jfk.wav";
-  let testAudioPath: string;
+describe('Whisper Model', () => {
+  let whisperInstance: { model: WhisperModelType; enc: Tokenizer } | undefined = undefined
+  const testModel: WhisperModel = 'tiny.en'
+  const testAudioUrl = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/jfk.wav'
+  let testAudioPath: string
 
   beforeAll(async () => {
-    console.log(`Initializing Whisper model: ${testModel}...`);
+    console.log(`Initializing Whisper model: ${testModel}...`)
     try {
-      const whisper = await init_whisper(testModel);
+      const whisper = await init_whisper(testModel)
       whisperInstance = {
         model: whisper[0],
         enc: whisper[1],
-      };
-      console.log(`Model ${testModel} initialized.`);
+      }
+      console.log(`Model ${testModel} initialized.`)
       testAudioPath = await env.fetchSave(
         testAudioUrl,
         `jfk_${id(testAudioUrl)}.wav`,
-        env.CACHE_DIR
-      );
-      console.log(`Test audio saved to: ${testAudioPath}`);
+        env.CACHE_DIR,
+      )
+      console.log(`Test audio saved to: ${testAudioPath}`)
     } catch (e) {
       console.error(
-        "Failed to initialize Whisper model or download audio for tests:",
-        e
-      );
+        'Failed to initialize Whisper model or download audio for tests:',
+        e,
+      )
     }
-  }, 100_000);
+  }, 100_000)
 
   test(
-    "init_whisper loads model and tokenizer",
+    'init_whisper loads model and tokenizer',
     {
       timeout: 120000,
     },
     () => {
-      expect(whisperInstance).toBeDefined();
-      if (!whisperInstance) return;
+      expect(whisperInstance).toBeDefined()
+      if (!whisperInstance) return
 
-      const { model, enc } = whisperInstance;
-      expect(model).toBeDefined();
-      expect(model.constructor.name).toBe("Whisper");
+      const { model, enc } = whisperInstance
+      expect(model).toBeDefined()
+      expect(model.constructor.name).toBe('Whisper')
       expect(model.is_multilingual).toBe(
-        MODELS[testModel].dims.n_vocab === 51865
-      );
-      expect(model.batch_size).toBe(1);
+        MODELS[testModel].dims.n_vocab === 51865,
+      )
+      expect(model.batch_size).toBe(1)
 
-      expect(enc).toBeDefined();
-      expect(enc.constructor.name).toBe("Tokenizer");
-      expect(enc.stop_tokens).toBeDefined();
-      expect(enc.stop_tokens.length).toBeGreaterThan(0);
-    }
-  );
+      expect(enc).toBeDefined()
+      expect(enc.constructor.name).toBe('Tokenizer')
+      expect(enc.stop_tokens).toBeDefined()
+      expect(enc.stop_tokens.length).toBeGreaterThan(0)
+    },
+  )
 
-  test("transcribe_file processes JFK sample", async () => {
+  test('transcribe_file processes JFK sample', async () => {
     if (!whisperInstance) {
       throw new Error(
-        "Whisper model instance not available for transcription test."
-      );
+        'Whisper model instance not available for transcription test.',
+      )
     }
     if (!testAudioPath) {
-      throw new Error("Test audio file path not available.");
+      throw new Error('Test audio file path not available.')
     }
 
-    console.log(`Transcribing file: ${testAudioPath}...`);
-    const { model, enc } = whisperInstance;
+    console.log(`Transcribing file: ${testAudioPath}...`)
+    const { model, enc } = whisperInstance
 
     const transcriptionResult = await transcribe_file(
       model,
       enc,
-      testAudioPath
-    );
+      testAudioPath,
+    )
 
-    console.log(`Transcription result: "${transcriptionResult}"`);
-
-    expect(typeof transcriptionResult).toBe("string");
-    if (typeof transcriptionResult !== "string") return;
+    expect(typeof transcriptionResult).toBe('string')
     expect(transcriptionResult.toLowerCase()).toContain(
-      "ask not what your country can do for you"
-    );
+      'ask not what your country can do for you',
+    )
     expect(transcriptionResult.toLowerCase()).toContain(
-      "ask what you can do for your country"
-    );
-  });
-});
+      'ask what you can do for your country',
+    )
+  })
+})

--- a/test/models/whisper.test.ts
+++ b/test/models/whisper.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect, beforeAll } from "vitest";
+import {
+  init_whisper,
+  transcribe_file,
+  MODELS,
+  type WhisperModel,
+  type Whisper as WhisperModelType,
+  type Tokenizer,
+  env,
+  id,
+} from "../../jsgrad/node.ts";
+
+describe("Whisper Model", () => {
+  let whisperInstance: { model: WhisperModelType; enc: Tokenizer } | undefined =
+    undefined;
+  const testModel: WhisperModel = "tiny.en";
+  const testAudioUrl =
+    "https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/jfk.wav";
+  let testAudioPath: string;
+
+  beforeAll(async () => {
+    console.log(`Initializing Whisper model: ${testModel}...`);
+    try {
+      const whisper = await init_whisper(testModel);
+      whisperInstance = {
+        model: whisper[0],
+        enc: whisper[1],
+      };
+      console.log(`Model ${testModel} initialized.`);
+      testAudioPath = await env.fetchSave(
+        testAudioUrl,
+        `jfk_${id(testAudioUrl)}.wav`,
+        env.CACHE_DIR
+      );
+      console.log(`Test audio saved to: ${testAudioPath}`);
+    } catch (e) {
+      console.error(
+        "Failed to initialize Whisper model or download audio for tests:",
+        e
+      );
+    }
+  }, 100_000);
+
+  test(
+    "init_whisper loads model and tokenizer",
+    {
+      timeout: 120000,
+    },
+    () => {
+      expect(whisperInstance).toBeDefined();
+      if (!whisperInstance) return;
+
+      const { model, enc } = whisperInstance;
+      expect(model).toBeDefined();
+      expect(model.constructor.name).toBe("Whisper");
+      expect(model.is_multilingual).toBe(
+        MODELS[testModel].dims.n_vocab === 51865
+      );
+      expect(model.batch_size).toBe(1);
+
+      expect(enc).toBeDefined();
+      expect(enc.constructor.name).toBe("Tokenizer");
+      expect(enc.stop_tokens).toBeDefined();
+      expect(enc.stop_tokens.length).toBeGreaterThan(0);
+    }
+  );
+
+  test("transcribe_file processes JFK sample", async () => {
+    if (!whisperInstance) {
+      throw new Error(
+        "Whisper model instance not available for transcription test."
+      );
+    }
+    if (!testAudioPath) {
+      throw new Error("Test audio file path not available.");
+    }
+
+    console.log(`Transcribing file: ${testAudioPath}...`);
+    const { model, enc } = whisperInstance;
+
+    const transcriptionResult = await transcribe_file(
+      model,
+      enc,
+      testAudioPath
+    );
+
+    console.log(`Transcription result: "${transcriptionResult}"`);
+
+    expect(typeof transcriptionResult).toBe("string");
+    if (typeof transcriptionResult !== "string") return;
+    expect(transcriptionResult.toLowerCase()).toContain(
+      "ask not what your country can do for you"
+    );
+    expect(transcriptionResult.toLowerCase()).toContain(
+      "ask what you can do for your country"
+    );
+  });
+});


### PR DESCRIPTION
Improvements include ensuring mono audio processing, adding type annotations for clarity, implementing linear interpolation for waveform resampling, and exporting the Whisper class with accompanying tests for model initialization and transcription.

Need to check if returning only a string is correct from `transcribe_waveform`, because the types are `Promise<string | string[]>`.

In my machine running this only test takes about 1 minute